### PR TITLE
fix(map): show user-facing error and try software rendering when WebG…

### DIFF
--- a/vitamind/src/App.test.jsx
+++ b/vitamind/src/App.test.jsx
@@ -1,10 +1,16 @@
 // src/App.test.jsx
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import App from './App';
 import mapboxgl from 'mapbox-gl'; // Import mapbox-gl to access its mock
 
 describe('App', () => {
+  beforeEach(() => {
+    // Reset mocks before each test so state from one test doesn't bleed into another
+    vi.clearAllMocks();
+    mapboxgl.supported.mockReturnValue(true);
+  });
+
   it('renders without crashing and displays the map container', () => {
     render(<App />);
 
@@ -12,16 +18,48 @@ describe('App', () => {
     const mapContainer = screen.getByTestId('map-container');
     expect(mapContainer).toBeInTheDocument();
 
-    // Optionally, check if mapboxgl.Map was called
+    // Mapbox Map should be initialized with software rendering allowed as fallback
     expect(mapboxgl.Map).toHaveBeenCalledTimes(1);
     expect(mapboxgl.Map).toHaveBeenCalledWith({
-      container: mapContainer, // The mock should receive the actual DOM element
+      container: mapContainer,
       style: 'mapbox://styles/mapbox/navigation-night-v1',
       center: [-122.3321, 47.6062],
       zoom: 9,
       projection: 'globe',
+      failIfMajorPerformanceCaveat: false,
     });
   });
 
-  // You might add more tests here, e.g., for user interactions if any
+  it('shows WebGL error overlay when WebGL is completely unavailable', () => {
+    // Both strict and lenient WebGL checks fail
+    mapboxgl.supported.mockReturnValue(false);
+
+    render(<App />);
+
+    expect(screen.getByTestId('map-error')).toBeInTheDocument();
+    expect(screen.getByText('Map Unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/WebGL, which is not available/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Chrome/i).length).toBeGreaterThan(0);
+
+    // Map should not have been initialized
+    expect(mapboxgl.Map).not.toHaveBeenCalled();
+  });
+
+  it('shows generic error overlay when map initialization throws', () => {
+    mapboxgl.Map.mockImplementationOnce(() => {
+      throw new Error('WebGL context lost');
+    });
+
+    render(<App />);
+
+    expect(screen.getByTestId('map-error')).toBeInTheDocument();
+    expect(screen.getByText('Map Unavailable')).toBeInTheDocument();
+    expect(screen.getByText(/failed to initialize/i)).toBeInTheDocument();
+  });
+
+  it('does not show error overlay on successful initialization', () => {
+    render(<App />);
+
+    expect(screen.queryByTestId('map-error')).not.toBeInTheDocument();
+  });
 });

--- a/vitamind/src/vitamind.css
+++ b/vitamind/src/vitamind.css
@@ -353,6 +353,48 @@ body {
   z-index: 500;
 }
 
+/* WebGL / Map Error Overlay */
+.map-error-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 100;
+  background-color: #272822;
+  border-radius: 14px;
+}
+
+.map-error-content {
+  color: #F8F8F2;
+  font-family: 'Fira Code', 'Source Code Pro', 'Consolas', 'Monaco', monospace;
+  text-align: center;
+  max-width: 420px;
+  padding: 30px;
+}
+
+.map-error-content h2 {
+  color: #F92672;
+  margin-bottom: 16px;
+}
+
+.map-error-content p {
+  color: #F8F8F2;
+  margin-bottom: 10px;
+  line-height: 1.5;
+}
+
+.map-error-content ol {
+  text-align: left;
+  color: #E6DB74;
+  margin-top: 8px;
+  padding-left: 20px;
+  line-height: 1.8;
+}
+
 @keyframes slide-down {
   from { transform: translateY(-100%); }
   to { transform: translateY(0); }


### PR DESCRIPTION
…L is disabled

Fixes #5

Chrome with hardware acceleration disabled returns false from mapboxgl.supported() (which defaults to failIfMajorPerformanceCaveat:true), causing a silent blank screen.

Changes:
- Detect WebGL availability at initial state time (useState lazy initialiser) to avoid setState-in-effect lint violations
- If strict WebGL check fails, try lenient check (failIfMajorPerformanceCaveat: false) before giving up; this allows Chrome's software WebGL renderer to be used when hardware acceleration is turned off
- Pass failIfMajorPerformanceCaveat: false to mapboxgl.Map constructor so software rendering is always permitted as a fallback
- On total WebGL failure, render a visible error overlay with Chrome-specific instructions (Settings → System → hardware acceleration)
- On map constructor throw, show a generic "failed to initialize" overlay
- Add CSS for .map-error-overlay / .map-error-content (Monokai theme)
- Update tests: cover WebGL-unavailable and init-throw error paths; update existing test for new Map constructor args

https://claude.ai/code/session_0175KVuG3fV9ACGZwAqVmzt4