### PR TITLE
docs: require Fixes/Closes keywords in PR bodies for auto-issue closure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ When performing development or deployment tasks:
 3. Fix any failures before opening a PR.
 
 ### Phase 3: Pull Request & Staging
-1. Open a PR to `main`, linked to the issue (e.g., "Fixes #123").
+1. Open a PR to `main`, using `Fixes #N` or `Closes #N` keywords in the PR body so GitHub auto-closes the issue on merge (e.g., "Fixes #123").
 2. `deploy-staging.yaml` triggers automatically and posts a comment on the PR with the staging URL.
 3. Respond to review feedback with new commits on the same branch. Do NOT merge.
 

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -26,7 +26,7 @@ Before proposing changes, understand the codebase:
 
 ## Phase 3: Pull Request & Staging
 
-1. **Open a PR** targeting `main`, linked to the issue (e.g. "Fixes #123").
+1. **Open a PR** targeting `main`, using `Fixes #N` or `Closes #N` keywords in the PR body so GitHub auto-closes the issue on merge (e.g. "Fixes #123").
 2. **Staging auto-deploys**: `deploy-staging.yaml` triggers automatically and posts a comment on the PR with the staging URL:
    `https://tommyroar.github.io/vitamind/staging/`
 3. **Wait for review**: Push new commits to the same branch in response to feedback. **Do NOT merge** — keep the PR open until the human maintainer merges it.


### PR DESCRIPTION
## Summary
- Update `ISSUES.md` Phase 3 and `CLAUDE.md` Phase 3 to mandate `Fixes #N` / `Closes #N` keywords in PR bodies
- Ensures GitHub auto-closes linked issues on merge going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)