### PR TITLE
ci: add GitHub environment tracking to staging and production workflows

### DIFF
--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  deployments: write
 
 concurrency:
   group: "github-pages-production"
@@ -16,6 +17,9 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: https://tommyroar.github.io/vitamind/
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  deployments: write
 
 concurrency:
   group: "github-pages-staging"
@@ -17,6 +18,9 @@ concurrency:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: https://tommyroar.github.io/vitamind/staging/
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Adds `environment: name/url` to both workflow jobs so GitHub creates tracked Deployment records
- Adds `deployments: write` permission to both workflows
- Staging PRs will now show a live "staging" deployment link in the PR deployments panel
- Production deploys will show in the repo sidebar under Environments

## Test plan
- [ ] Merge this PR and confirm a staging deployment appears in the PR deployments panel
- [ ] Confirm production environment appears in the repo sidebar after merge to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)