### PR TITLE
chore: Enable Dependabot for security and version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/vitamind"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    groups:
+      dependencies:
+        patterns:
+          - "*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Enables Dependabot to monitor and update dependencies for security vulnerabilities (CVEs) and new versions.

- Monitors `npm` dependencies in `/vitamind`.
- Monitors `github-actions` in the repository root.
- Scheduled for weekly checks.
- Uses grouping to reduce PR noise.