### PR TITLE
chore: rename github URLs tommyroar → robogeosociety

### DIFF
--- a/.claude/commands/wiki.md
+++ b/.claude/commands/wiki.md
@@ -1,4 +1,4 @@
-Push one or more markdown files to the GitHub wiki for tommyroar/vitamind.
+Push one or more markdown files to the GitHub wiki for robogeosociety/vitamind.
 
 Usage: /wiki <page-name> or /wiki (to update an existing file you describe)
 
@@ -8,7 +8,7 @@ Steps:
    - All other pages use their natural name, e.g. `costs.md`.
 2. Clone (or reuse) the wiki repo into a temp directory:
    ```
-   git clone https://x-access-token:$(gh auth token)@github.com/tommyroar/vitamind.wiki.git /tmp/vitamind.wiki
+   git clone https://x-access-token:$(gh auth token)@github.com/robogeosociety/vitamind.wiki.git /tmp/vitamind.wiki
    ```
    If `/tmp/vitamind.wiki` already exists, run `git pull` inside it instead.
 3. Write the page content to `/tmp/vitamind.wiki/<PageName>.md`.
@@ -20,7 +20,7 @@ Steps:
    git add -A
    git diff --cached --quiet || git commit -m "docs: update <PageName>"
    GH_TOKEN=$(gh auth token)
-   git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/tommyroar/vitamind.wiki.git
+   git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/robogeosociety/vitamind.wiki.git
    git push
    ```
-5. Confirm success and print the wiki URL: `https://github.com/tommyroar/vitamind/wiki/<PageName>`
+5. Confirm success and print the wiki URL: `https://github.com/robogeosociety/vitamind/wiki/<PageName>`

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,6 +1,6 @@
 name: Claude PR Assistant
 
-# Canonical @claude responder — source of truth: tommyroar/.github.
+# Canonical @claude responder — source of truth: robogeosociety/.github.
 # Synced into every owned repo by scripts/sync.sh. Also selectable one-click
 # from the Actions "New workflow" UI. Auth: CLAUDE_CODE_OAUTH_TOKEN (Max sub).
 

--- a/.github/workflows/deploy-spa.yaml
+++ b/.github/workflows/deploy-spa.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: production
-      url: https://tommyroar.github.io/vitamind/
+      url: https://robogeosociety.github.io/vitamind/
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -56,5 +56,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '**Staging preview deployed:** https://tommyroar.github.io/vitamind/staging/'
+              body: '**Staging preview deployed:** https://robogeosociety.github.io/vitamind/staging/'
             })

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@
 
 Two deployment workflows exist:
 
-1. **Staging Preview** (`deploy-staging.yaml`): Auto-deploys on any Pull Request targeting `main`. After deploy, posts a PR comment with the staging URL. Verify at `https://tommyroar.github.io/vitamind/staging/`.
-2. **Production** (`deploy-spa.yaml`): Auto-deploys on merge to `main`. Verify at `https://tommyroar.github.io/vitamind/`.
+1. **Staging Preview** (`deploy-staging.yaml`): Auto-deploys on any Pull Request targeting `main`. After deploy, posts a PR comment with the staging URL. Verify at `https://robogeosociety.github.io/vitamind/staging/`.
+2. **Production** (`deploy-spa.yaml`): Auto-deploys on merge to `main`. Verify at `https://robogeosociety.github.io/vitamind/`.
 
-Docs are maintained directly in the [GitHub Wiki](https://github.com/tommyroar/vitamind/wiki). Use the `/wiki` slash command to push updates.
+Docs are maintained directly in the [GitHub Wiki](https://github.com/robogeosociety/vitamind/wiki). Use the `/wiki` slash command to push updates.
 
 ## Development Protocol
 
@@ -38,7 +38,7 @@ When performing development or deployment tasks:
 
 ### Phase 4: Deployment & Closure
 1. After the human merges to `main`, `deploy-spa.yaml` triggers automatically.
-2. Verify the fix at `https://tommyroar.github.io/vitamind/`.
+2. Verify the fix at `https://robogeosociety.github.io/vitamind/`.
 3. Only close the issue after confirming the production deployment succeeded.
 ## Pull requests — the "newspaper" framework
 
@@ -46,5 +46,5 @@ PR descriptions follow the **newspaper / information-pyramid** format: one self-
 front page (kicker → headline → dek → masthead → why → what → mermaid flow → screens →
 verification → risk) that reads top-to-bottom on an iPad-mini portrait display (1–2 pages;
 up to 4 for very complex *code* changes). Rebuild from the **full** diff, never append.
-Full rules: <https://github.com/tommyroar/.github/blob/main/PR_FRAMEWORK.md>. CI validates
-the body via the `pr-newspaper` workflow (the reusable gate in `tommyroar/pr-newspaper`).
+Full rules: <https://github.com/robogeosociety/.github/blob/main/PR_FRAMEWORK.md>. CI validates
+the body via the `pr-newspaper` workflow (the reusable gate in `robogeosociety/pr-newspaper`).

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -5,13 +5,13 @@ This project uses a two-workflow deployment strategy to GitHub Pages via the `gh
 ## Infrastructure Overview
 
 - **Deployment Branch**: `gh-pages`
-- **Production URL**: `https://tommyroar.github.io/vitamind/`
-- **Staging URL**: `https://tommyroar.github.io/vitamind/staging/`
+- **Production URL**: `https://robogeosociety.github.io/vitamind/`
+- **Staging URL**: `https://robogeosociety.github.io/vitamind/staging/`
 - **GitHub Pages Setting**: Must be set to **"Deploy from a branch"** targeting `gh-pages` at `/ (root)`.
 
 ## Docs
 
-Documentation is maintained directly in the [GitHub Wiki](https://github.com/tommyroar/vitamind/wiki). Use the `/wiki` slash command to push updates.
+Documentation is maintained directly in the [GitHub Wiki](https://github.com/robogeosociety/vitamind/wiki). Use the `/wiki` slash command to push updates.
 
 ## Workflows
 
@@ -35,4 +35,4 @@ Both workflows use `peaceiris/actions-gh-pages` with `keep_files: true` so that 
 
 ## Security & Secrets
 
-The SPA requires `VITE_MAPBOX_ACCESS_TOKEN` (a Mapbox public access token secured via domain whitelisting to `tommyroar.github.io/*`).
+The SPA requires `VITE_MAPBOX_ACCESS_TOKEN` (a Mapbox public access token secured via domain whitelisting to `robogeosociety.github.io/*`).

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -28,11 +28,11 @@ Before proposing changes, understand the codebase:
 
 1. **Open a PR** targeting `main`, using `Fixes #N` or `Closes #N` keywords in the PR body so GitHub auto-closes the issue on merge (e.g. "Fixes #123").
 2. **Staging auto-deploys**: `deploy-staging.yaml` triggers automatically and posts a comment on the PR with the staging URL:
-   `https://tommyroar.github.io/vitamind/staging/`
+   `https://robogeosociety.github.io/vitamind/staging/`
 3. **Wait for review**: Push new commits to the same branch in response to feedback. **Do NOT merge** — keep the PR open until the human maintainer merges it.
 
 ## Phase 4: Production & Closure
 
 1. After the human merges to `main`, `deploy-spa.yaml` triggers automatically.
-2. Verify the fix at `https://tommyroar.github.io/vitamind/`.
+2. Verify the fix at `https://robogeosociety.github.io/vitamind/`.
 3. Close the issue only after confirming the production deployment succeeded.

--- a/vitamind/src/App.jsx
+++ b/vitamind/src/App.jsx
@@ -1097,7 +1097,7 @@ function App() {
                   <p 
                     id="mkdocs-link" 
                   >
-                    Documentation: <a href="https://tommyroar.github.io/vitamind/docs/" target="_blank" rel="noopener noreferrer" className="calendar-link">Vitamind Docs</a>
+                    Documentation: <a href="https://robogeosociety.github.io/vitamind/docs/" target="_blank" rel="noopener noreferrer" className="calendar-link">Vitamind Docs</a>
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
`fleet` — **ORG RENAME**

Mechanical URL sweep after the tommyroar → robogeosociety org migration — staging/production Pages URLs in DEPLOY.md/ISSUES.md/CLAUDE.md and both deploy workflows, the wiki links + `/wiki` command clone URLs, the claude.yml source-of-truth comment, the Mapbox whitelist-domain doc note, and the in-app docs link in `vitamind/src/App.jsx`. Old github.com URLs redirect, so those are canonical cleanup; the Pages project URLs (`tommyroar.github.io/vitamind/...` → `robogeosociety.github.io/vitamind/...`) do NOT redirect and were hard-404s until this change.

## Verification
- `grep -rn tommyroar` — remaining hits: 0
- Staging preview auto-deploys on this PR; merge triggers the production deploy that ships the fixed in-app docs link.

## Risk & rollout
- Doc/URL-only plus one JSX href (no logic change); redirects cover the github.com transition. NOTE: the Mapbox token URL-allowlist for this SPA lives in robogeosociety/infra `mapbox/token.tf` and only changes after `terraform apply` on the Mac mini — tiles on the new Pages origin depend on that apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)