### PR TITLE
ci: verify dependency PRs — lint, test, build on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+# CI — the check that actually verifies a change, including dependency bumps.
+#
+# The deploy workflows can't do this job: deploy-staging skips dependabot entirely
+# (`if: github.actor != 'dependabot[bot]'`, correctly — dependabot PRs must not deploy
+# and can't read deploy secrets), which left dependency PRs with *nothing verified* and
+# no way through the merge gate. This runs on every PR, needs no secrets, and deploys
+# nothing.
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: vitamind
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 20
+
+      - name: Install
+        run: npm install
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm test
+
+      # No Mapbox token here on purpose — dependabot PRs can't read secrets, and a build
+      # that only proves "the bundle compiles" doesn't need one. The token-bearing build
+      # still runs in deploy-spa on merge to main.
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
**Why 12 dependabot PRs are stuck** (oldest open since 2026-04-07): `deploy-staging.yaml` carries `if: github.actor != 'dependabot[bot]'` on its only PR-triggered job — correctly, since dependabot PRs must not deploy and can't read deploy secrets. But that workflow was the *only* thing running on PRs, so dependency bumps got **zero verification** and surfaced in the merge gate as "nothing verified — 1 skipped/neutral check(s)". Nothing was broken; nothing was ever checked.

This adds a real CI lane: `npm install` → `lint` → `test` → `build`, on every PR and on main. No secrets (so dependabot can run it), no deploys. The token-bearing production build still happens in `deploy-spa` on merge.

Verified locally against this tree: eslint clean, **28 tests pass**, build succeeds.

Once merged I'll rebase the open dependency PRs so they pick this up, then merge the green ones. Note GitHub also reports **13 vulnerabilities** on the default branch (7 high) — merging the backlog should clear most.

🤖 Generated with [Claude Code](https://claude.com/claude-code)